### PR TITLE
Add goreleaser and Dockerfile

### DIFF
--- a/.github/workflows/go_releaser.yaml
+++ b/.github/workflows/go_releaser.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   goreleaser:

--- a/.github/workflows/go_releaser.yaml
+++ b/.github/workflows/go_releaser.yaml
@@ -1,0 +1,30 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v5
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go_releaser.yaml
+++ b/.github/workflows/go_releaser.yaml
@@ -13,18 +13,21 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: '^1.23'
-      -
-        name: Run GoReleaser
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser

--- a/.github/workflows/go_releaser.yaml
+++ b/.github/workflows/go_releaser.yaml
@@ -12,6 +12,13 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        arch: [amd64, arm64]
+        exclude:
+          - os: windows-latest
+            arch: arm64
     steps:
       -
         name: Checkout
@@ -21,11 +28,13 @@ jobs:
       -
         name: Set up Go
         uses: actions/setup-go@v5
+        with:
+          go-version: '^1.23'
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          args: release --clean
+          args: release --clean --single-target
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go_releaser.yaml
+++ b/.github/workflows/go_releaser.yaml
@@ -12,13 +12,6 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        arch: [amd64, arm64]
-        exclude:
-          - os: windows-latest
-            arch: arm64
     steps:
       -
         name: Checkout
@@ -35,6 +28,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          args: release --clean --single-target
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gotest.yaml
+++ b/.github/workflows/gotest.yaml
@@ -1,0 +1,21 @@
+name: Go
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.23' ]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+      # You can test your matrix by printing the current Go version
+      - name: Display Go version
+        run: go version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM alpine
+FROM debian
 COPY discord-dl /usr/local/bin/discord-dl
 ENV PATH=/bin:/usr/bin:/usr/local/bin
+RUN apt-get update && \
+    apt-get install -y libsqlite3-0 ca-certificates && \
+    rm -rf /var/lib/apt/lists/* && update-ca-certificates
 ENTRYPOINT ["discord-dl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ COPY discord-dl /usr/local/bin/discord-dl
 ENV PATH=/bin:/usr/bin:/usr/local/bin
 RUN apt-get update && \
     apt-get install -y libsqlite3-0 ca-certificates && \
-    rm -rf /var/lib/apt/lists/* && update-ca-certificates
+    rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["discord-dl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine
+COPY discord-dl /usr/local/bin/discord-dl
+ENV PATH=/bin:/usr/bin:/usr/local/bin
+ENTRYPOINT ["discord-dl"]

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -18,7 +18,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -37,3 +37,7 @@ nfpms:
     release: 1
     section: default
     priority: extra
+dockers:
+  - image_templates:
+      - "ghcr.io/arran4/discord-dl:{{ .Tag }}"
+      - "ghcr.io/arran4/discord-dl:latest"

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -6,6 +6,8 @@ builds:
     dir: .
     env:
       - CGO_ENABLED=1
+    goarch:
+      - amd64
 archives:
   -
     format_overrides:

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -8,6 +8,8 @@ builds:
       - CGO_ENABLED=1
     goarch:
       - amd64
+    goos:
+      - linux
 archives:
   -
     format_overrides:

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -5,7 +5,7 @@ builds:
     binary: "discord-dl"
     dir: .
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
 archives:
   -
     format_overrides:

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -6,10 +6,6 @@ builds:
     dir: .
     env:
       - CGO_ENABLED=1
-    goarch:
-      - amd64
-    goos:
-      - linux
 archives:
   -
     format_overrides:

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,4 +1,5 @@
-project_name: rntocase
+version: 2
+project_name: discord-dl
 builds:
   -
     binary: "discord-dl"

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,0 +1,38 @@
+project_name: rntocase
+builds:
+  -
+    binary: "discord-dl"
+    dir: .
+    env:
+      - CGO_ENABLED=0
+archives:
+  -
+    format_overrides:
+      - goos: windows
+        format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+nfpms:
+  -
+    vendor: de_inferno
+    homepage: https://github.com/Yakabuff/
+    maintainer: Yakabuff <yakabuff@fosstodon.org>
+    description: NA
+    license: Private
+    formats:
+      - apk
+      - deb
+      - rpm
+      - termux.deb
+      - archlinux
+    release: 1
+    section: default
+    priority: extra

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -6,6 +6,10 @@ builds:
     dir: .
     env:
       - CGO_ENABLED=1
+    goarch:
+      - amd64
+    goos:
+      - linux
 archives:
   -
     format_overrides:


### PR DESCRIPTION
These will need to modified slightly to put in the correct details as to the npmf contact details (I just made them up, sorry) and the docker endpoint will need to be changed..

This creates a downloadable version every time you semantically tag the repo which will look like this:
https://github.com/arran4/discord-dl/releases/tag/v2.1.1-alpha

The idea is to give people who don't know how to use go the potential to use the app.

Windows and Mac OS can be done, but it will have to be with separate goreleaser files, and different "jobs" in to goreleaser file, because of the CGO dependency (linking to libsqlite) however it's possible to do just I haven't elsewhere (no reference.)